### PR TITLE
allows for overriding the makeId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Volleyball is a minimal Connect-style middleware function which logs incoming re
 
 Logging HTTP cycles can be approached in several ways, each with its own drawbacks:
 
-*   Log only upon **request**. Drawback: we cannot log the corresponding response, which happens later (if at all).
-*   Log only upon **response**, attaching the request. Drawback A: if the server never sends a response, e.g. due to a bug, the request will not be logged either. Drawback B: two temporally distinct events are conflated, misleadingly.
-*   Log both upon **request** and **response**. Drawback: it is not necessarily clear which responses are for which requests.
+-   Log only upon **request**. Drawback: we cannot log the corresponding response, which happens later (if at all).
+-   Log only upon **response**, attaching the request. Drawback A: if the server never sends a response, e.g. due to a bug, the request will not be logged either. Drawback B: two temporally distinct events are conflated, misleadingly.
+-   Log both upon **request** and **response**. Drawback: it is not necessarily clear which responses are for which requests.
 
 Volleyball takes the last approach, and assigns randomly-generated ids to label request-response pairs. It is designed for student project development, teaching beginning programmers how HTTP servers and asynchronicity work. It may also be useful as a low-configuration debug tool.
 
@@ -54,13 +54,17 @@ The `debug` property logs using the [`debug`](https://github.com/visionmedia/deb
 | string   | uses a new debug instance with a custom namespace                                                                        |
 | function | uses any function, such as a pre-generated debug instance. Note that the function will be called with colorized strings. |
 
+The `makId` property specifies a custom request id generation function. It MUST be a funciton that returns a string.
+
+See `src/id.js` for the default `makeId` implementation.
+
 ## Related and Alternatives
 
 For more powerful, configurable, and compatible logging needs, check out:
 
-*   [debug](https://github.com/visionmedia/debug#readme)
-*   [morgan](https://github.com/expressjs/morgan#readme)
-*   [morgan-debug](https://github.com/ChiperSoft/morgan-debug#readme)
-*   [winston](https://github.com/winstonjs/winston#readme)
-*   [express-winston](https://github.com/bithavoc/express-winston#readme)
-*   [node-bunyan](https://github.com/trentm/node-bunyan/#readme)
+-   [debug](https://github.com/visionmedia/debug#readme)
+-   [morgan](https://github.com/expressjs/morgan#readme)
+-   [morgan-debug](https://github.com/ChiperSoft/morgan-debug#readme)
+-   [winston](https://github.com/winstonjs/winston#readme)
+-   [express-winston](https://github.com/bithavoc/express-winston#readme)
+-   [node-bunyan](https://github.com/trentm/node-bunyan/#readme)

--- a/lib/volleyball.js
+++ b/lib/volleyball.js
@@ -13,6 +13,8 @@ var makeId = require('./id');
 var sp = ' ';
 module.exports = Volleyball(); // eslint-disable-line new-cap
 
+module.exports.makeId = makeId;
+
 function Volleyball() {
   var config = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   // items shared across multiple req-res cycles, for a given volleyball
@@ -22,7 +24,7 @@ function Volleyball() {
     // items shared between the request and response of just one cycle
     var cycle = {
       log: log,
-      id: makeId(),
+      id: config.makeId ? config.makeId() : makeId(),
       time: process.hrtime()
     };
     logReq(req, cycle);

--- a/src/volleyball.js
+++ b/src/volleyball.js
@@ -9,6 +9,7 @@ const makeId = require('./id')
 const sp = ' '
 
 module.exports = Volleyball() // eslint-disable-line new-cap
+module.exports.makeId = makeId
 
 function Volleyball(config = {}) {
 	// items shared across multiple req-res cycles, for a given volleyball
@@ -18,7 +19,7 @@ function Volleyball(config = {}) {
 		// items shared between the request and response of just one cycle
 		const cycle = {
 			log: log,
-			id: makeId(),
+			id: config.makeId ? config.makeId() : makeId(),
 			time: process.hrtime(),
 		}
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,18 @@ describe('An Express app', function() {
 		it('logs requests and responses', test)
 	})
 
+	describe('using volleyball with custom makeId', () => {
+		function makeId() {
+			return 'IDID'
+		}
+
+		beforeEach(function() {
+			app.use(volleyball.custom({ makeId }))
+		})
+
+		it('logs reuests and responses', test)
+	})
+
 	describe('using volleyball with debug true', function() {
 		beforeEach(function() {
 			app.use(volleyball.custom({ debug: true }))


### PR DESCRIPTION
This allows for a customized request id generator.

In particular I've been using it with `continuation-local-storage` to get a "request id" that can be used by any async resource in a given express "request thread"

https://www.npmjs.com/package/continuation-local-storage

A bit like this:
```
const {
  createNamespace,
  getNamespace,
} = require('continuation-local-storage')
const volleyball = require('volleyball')
const makeId = require('./id')

const express = require('express')

const app = express()

const THREAD_ID_NS = 'THREAD_ID_NS'
const THREAD_ID = 'THREAD_ID'

const threadNS = createNamespace(THREAD_ID_NS)
app.use((req, res, next) => {
  const ns = getNamespace(THREAD_ID_NS)
  ns.bindEmitter(req)
  ns.bindEmitter(res)
  threadNS.run(() => next())
})

app.use(volleyball.custom({
  makeId: () => {
    const ns = getNamespace(THREAD_ID_NS)
    const threadId = makeId()
    ns.set(THREAD_ID, threadId)
    return threadId
  }
}))

function threadNSLogger (...args) {
  const ns = getNamespace(THREAD_ID_NS)
  const id = ns.get(THREAD_ID)
  if (id) {
    console.log(id, ...args)
  }
  else {
    console.log(...args)
  }
}


const Sequelize = require('sequelize')
const db = new Sequelize('postgres://localhost:5432/cls-logger-db', {
  logging: (query) => {
    if (process.env.LOG_SQL === "true") {
      threadNSLogger('——> ' + query)
    }
  }
})

}))

```
---

### Assignee Tasks

*   [x] added unit tests
*   [x] written relevant docs
